### PR TITLE
chore(utils): add techStack icons

### DIFF
--- a/src/utils/techIcons.js
+++ b/src/utils/techIcons.js
@@ -48,7 +48,7 @@ const techIcons = {
   MongoDB: <SiMongodb />,
   Mongoose: <SiMongoose />,
   Swagger: <SiSwagger />,
-  CommitLink: <SiCommitlint />,
+  CommitLint: <SiCommitlint />,
   Render: <SiRender />,
 };
 

--- a/src/utils/techIcons.js
+++ b/src/utils/techIcons.js
@@ -21,6 +21,8 @@ import {
   SiMongodb,
   SiMongoose,
   SiSwagger,
+  SiCommitlint,
+  SiRender,
 } from 'react-icons/si';
 
 const RoR = 'Ruby on Rails';
@@ -46,6 +48,8 @@ const techIcons = {
   MongoDB: <SiMongodb />,
   Mongoose: <SiMongoose />,
   Swagger: <SiSwagger />,
+  CommitLink: <SiCommitlint />,
+  Render: <SiRender />,
 };
 
 export default techIcons;

--- a/src/utils/techIcons.js
+++ b/src/utils/techIcons.js
@@ -20,6 +20,7 @@ import {
   SiExpress,
   SiMongodb,
   SiMongoose,
+  SiSwagger,
 } from 'react-icons/si';
 
 const RoR = 'Ruby on Rails';
@@ -44,6 +45,7 @@ const techIcons = {
   ExpressJS: <SiExpress />,
   MongoDB: <SiMongodb />,
   Mongoose: <SiMongoose />,
+  Swagger: <SiSwagger />,
 };
 
 export default techIcons;


### PR DESCRIPTION
## What & Why
Add tech stack icons for a new project that I'll be adding. 

## Changes Made
- Updated techIcons file with new  `swagger`, `commitlint` and `render` react icons

## How to Test
1. Visit https://gladwinramantso.netlify.app/#portfolio
2. Click **View Details** button on **Portfolio Data** project. Below the project title, you will see Tech Stack list.


## Screenshots (if applicable)
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/0415c6aa-29f1-41b2-93df-ba376e2b6098" />


## Notes / Concerns
N/A
