### PR TITLE
refactor(services): update services section title and text

### DIFF
--- a/src/Components/services/services.css
+++ b/src/Components/services/services.css
@@ -2,13 +2,13 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 3rem;
+  align-items: stretch;
 }
 
 .service {
   background: var(--color-bg-variant);
   border-radius: 0 0 2rem 2rem;
   border: 1px solid var(--color-primary);
-  height: max-content;
   transition: var(--transition);
 }
 


### PR DESCRIPTION
## What & Why
Communicate clearly the services I offer, the previous version of services reads like a CV dumped into cards and did not do any justice in properly highlighting the services I provide as a Software Developer. 

## Changes Made
- Updated `title` and `text` on the services section from the server.
- Updated styles and allowed `grid` to stretch cards automatically, instead of restricting card height.

## How to Test
Visit: [https://gladwinramantso.netlify.app/#services]()

## Screenshots (if applicable)
<img width="1334" height="607" alt="image" src="https://github.com/user-attachments/assets/23b7d772-b88b-4866-9e68-430a3e3214cc" />

## Notes / Concerns
N/A
