### PR TITLE
test(Footer): add test cases for footer nav and social links

### DIFF
--- a/src/Components/footer/Footer.jsx
+++ b/src/Components/footer/Footer.jsx
@@ -33,7 +33,7 @@ const Footer = () => (
       </li>
     </ul>
 
-    <div className="footer__socials">
+    <div className="footer__socials" data-testid="footer-socials">
       <a href="https://facebook.com/" target="_blank" rel="noreferrer">
         <FaFacebookF />
       </a>

--- a/src/Components/footer/__test__/Footer.test.jsx
+++ b/src/Components/footer/__test__/Footer.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen, within } from '@testing-library/react';
+import Footer from '../Footer';
+
+describe('Footer component', () => {
+  test('should render nav links and social media icons', () => {
+    render(<Footer />);
+
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+
+    const footerLogo = screen.getByRole('link', { name: /gladwin/i });
+    expect(footerLogo).toBeInTheDocument();
+    expect(footerLogo).toHaveAttribute('href', '#home');
+
+    const links = screen.getAllByRole('listitem');
+    expect(links).toHaveLength(7);
+    links.forEach((link) => {
+      expect(link).toBeInTheDocument();
+    });
+
+    const socialContainer = screen.getByTestId('footer-socials');
+    const socialLinks = within(socialContainer).getAllByRole('link');
+
+    expect(socialLinks).toHaveLength(3);
+
+    expect(socialLinks[0]).toHaveAttribute('href', 'https://facebook.com/');
+    expect(socialLinks[1]).toHaveAttribute(
+      'href',
+      'https://twitter.com/ramgt001',
+    );
+    expect(socialLinks[2]).toHaveAttribute(
+      'href',
+      'https://www.instagram.com/',
+    );
+  });
+
+  test('should have copyright text', () => {
+    render(<Footer />);
+
+    expect(screen.getByText(/gladwin tshepo ramantso/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What & Why
Add test cases for `Footer` navigation links. logo and social media links

## Changes Made
- Added nav links and social media links test cases
- Added test case for copyright text
- Enforced conventional commits via commitlint + husky

## How to Test
1. run `npm run test`

## Screenshots (if applicable)
<img width="1365" height="767" alt="image" src="https://github.com/user-attachments/assets/f26b325c-65fa-444c-af43-f285cb54559e" />


## Notes / Concerns
- Pass test cases for About component
- Passed test cases for the Footer component
