### PR TITLE
test(articles): add unit test cases on Articles component with snapshot

### DIFF
--- a/src/Components/articles/Articles.jsx
+++ b/src/Components/articles/Articles.jsx
@@ -9,7 +9,7 @@ const Articles = () => {
 
       <div className="container articles__container">
         <article className="article__card">
-          <div className="article__content">
+          <div className="article__content" data-testid="paragraphs">
             <h3>Imposter Syndrome as a Developer</h3>
             <p className="article__meta">
               Written in 2023 • Personal Growth • Career Transition

--- a/src/Components/articles/__test__/Article.test.jsx
+++ b/src/Components/articles/__test__/Article.test.jsx
@@ -1,0 +1,50 @@
+import { screen, render } from '@testing-library/react';
+import Articles from '../Articles';
+
+describe('Articles component', () => {
+  beforeEach(() => {
+    render(<Articles />);
+  });
+  test('should render heading with correct text', () => {
+    expect(
+      screen.getByRole('heading', { name: /beyond code/i, level: 5 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /articles & thoughts/i, level: 2 }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: /imposter syndrome as a developer/i,
+        level: 3,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  test('should render three paragraphs', () => {
+    const wrapper = screen.getByTestId('paragraphs');
+    const paragraphs = wrapper.querySelectorAll('p');
+
+    expect(paragraphs).toHaveLength(3);
+
+    expect(paragraphs[0]).toHaveClass('article__meta');
+    expect(paragraphs[1]).toHaveClass('article__description');
+    expect(paragraphs[2]).toHaveClass('article__reflection');
+  });
+
+  test('should render navigation link with href', () => {
+    const link = screen.getByRole('link', { name: /read full article/i });
+    expect(link).toHaveAttribute(
+      'href',
+      'https://medium.com/@tgramantso/dealing-with-imposter-syndrome-4310ecb3deea',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  describe('snapshots', () => {
+    test('should match component snapshot', () => {
+      const { container } = render(<Articles />);
+      expect(container).toMatchSnapshot();
+    });
+  });
+});

--- a/src/Components/articles/__test__/__snapshots__/Article.test.jsx.snap
+++ b/src/Components/articles/__test__/__snapshots__/Article.test.jsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Articles component snapshots should match component snapshot 1`] = `
+<div>
+  <section
+    id="articles"
+  >
+    <h5>
+      Beyond Code
+    </h5>
+    <h2>
+      Articles & Thoughts
+    </h2>
+    <div
+      class="container articles__container"
+    >
+      <article
+        class="article__card"
+      >
+        <div
+          class="article__content"
+          data-testid="paragraphs"
+        >
+          <h3>
+            Imposter Syndrome as a Developer
+          </h3>
+          <p
+            class="article__meta"
+          >
+            Written in 2023 • Personal Growth • Career Transition
+          </p>
+          <p
+            class="article__description"
+          >
+            A reflection on transitioning from Accounting to Software Development, navigating self-doubt, and embracing a growth mindset. This piece explores how failure, collaboration, and persistence shape the journey of becoming a developer.
+          </p>
+          <p
+            class="article__reflection"
+          >
+            <strong>
+              Reflection:
+            </strong>
+             Looking back, this was written at a time when everything felt uncertain. Today, I see those moments as a necessary stepping stone that strengthened my confidence and resilience as a developer.
+          </p>
+          <a
+            class="btn btn-primary"
+            href="https://medium.com/@tgramantso/dealing-with-imposter-syndrome-4310ecb3deea"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Read Full Article
+          </a>
+        </div>
+      </article>
+    </div>
+  </section>
+</div>
+`;


### PR DESCRIPTION
## What & Why
Unit test Article component with snapshots that match the component

## Changes Made
- Add test cases for `heading`, `paragraphs` and `navigation link`
- Enforced conventional commits via commitlint + husky

## How to Test
1.  `npm test`

## Screenshots (if applicable)
<img width="1361" height="767" alt="image" src="https://github.com/user-attachments/assets/ded20f8f-0941-4b95-a15c-0216f60dd7ed" />

## Notes / Concerns
- All test cases pass
