### PR TITLE
ci/dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 Dockerfile
 .git
+.env
+.env.local
+.env*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # Stage 1: Build the React app
-FROM node:alpine AS builder
+FROM node:22-trixie-slim AS builder
 WORKDIR /app
-ADD package*.json ./
-RUN npm install
-ADD . .
+COPY package*.json ./
+RUN npm ci 
+COPY . .
+ARG REACT_APP_API_URL
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
 RUN npm run build
 
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 COPY --from=builder /app/build /usr/share/nginx/html
 EXPOSE 80
-CMD ["nginx", "-g", "daemon off;"]

--- a/src/Components/contact/__test__/Contact.test.jsx
+++ b/src/Components/contact/__test__/Contact.test.jsx
@@ -92,6 +92,7 @@ describe('Contact Component', () => {
     await user.click(screen.getByRole('button', { name: /send message/i }));
 
     expect(toast.loading).toHaveBeenCalledWith('Sending message...');
+    expect(toast.loading).toHaveBeenCalledTimes(1);
   });
 
   test('should call the API with the correct payload on submit', async () => {

--- a/src/Components/experience/Experience.jsx
+++ b/src/Components/experience/Experience.jsx
@@ -49,7 +49,7 @@ const Experience = () => {
           <div className="experience__content">
             {isLoading
               ? skeletons.map((_, i) => <SkillsCardSkeleton key={i} />)
-              : frontend.map((item) => (
+              : frontend?.map((item) => (
                   <SkillsCard
                     key={item._id}
                     language={item.language}
@@ -64,7 +64,7 @@ const Experience = () => {
           <div className="experience__content">
             {isLoading
               ? skeletons.map((_, i) => <SkillsCardSkeleton key={i} />)
-              : backend.map((item) => (
+              : backend?.map((item) => (
                   <SkillsCard
                     key={item._id}
                     language={item.language}
@@ -79,7 +79,7 @@ const Experience = () => {
           <div className="experience__content">
             {isLoading
               ? skeletons.map((_, i) => <SkillsCardSkeleton key={i} />)
-              : tools.map((item) => (
+              : tools?.map((item) => (
                   <SkillsCard
                     key={item._id}
                     language={item.language}

--- a/src/Components/experience/__tests__/Experience.test.jsx
+++ b/src/Components/experience/__tests__/Experience.test.jsx
@@ -1,0 +1,68 @@
+import { screen, render, waitFor } from '@testing-library/react';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import axios from 'axios';
+import Experience from '../Experience';
+// import API from '../../../utils/api';
+
+jest.mock('../../../utils/api', () => ({
+  experience: 'https://example.com/api/experience',
+}));
+
+jest.mock('axios');
+
+const mockedAxios = jest.mocked(axios);
+
+const createTestQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+};
+
+const renderWithClient = (ui) => {
+  const queryClient = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+};
+
+describe('Experience Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('should render heading correctly', () => {
+    mockedAxios.mockResolvedValueOnce({ data: { experiences: [] } });
+    renderWithClient(<Experience />);
+    expect(
+      screen.getByRole('heading', { name: /skills /i, level: 5 }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: /my experience/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('should not show error message initially, only show once request failed', async () => {
+    mockedAxios.mockRejectedValueOnce(new Error('Network Error'));
+
+    renderWithClient(<Experience />);
+
+    expect(
+      screen.queryByRole('heading', { name: /network error/i, level: 2 }),
+    ).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /network error/i }),
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## What & Why (Summary)
Refactor `Dockerfile`, update the node base image and add `ARG` and `ENV` also `dockerignore` `.env` file

## Changes Made
- Docker node base image from `node:alpine` to `node:22-trixie-slim`
- Added  arguments`ARG` and Environment `ENV` variables
- Build Docker image from the updated `Dockerfile` using the following command `docker build --build-arg REACT_APP_API_URL=http://localhost:3000 --tag portfolio-frontend:1.0.0 .`
- Ran Docker container from the recently built image i.e `portfolio-frontend:1.0.0`. using the following command: 
`docker run -d -p 8080:80 --name portfolio-frontend \
  > --env-file .env \
  > -v ./src:/app/src \
  > -v /app/node_modules \
  > --network portfolio-net \
  > portfolio-frontend:1.0.0`

## How to Test
1. `docker ps -a` List all containers and `portfolio-frontend` should be amongst other containers
2. `docker image ls` List all all images and `portfolio-frontend:1.0.0:` should be amongst other images
3. `docker network inspect portfolio-net` should verify that both portfolio-backend and frontend Containers share the same network 
4. Visit `http://localhost:8080/`

## Screenshots (if applicable)
<img width="1358" height="767" alt="image" src="https://github.com/user-attachments/assets/29734487-5022-4fbb-af38-22033a992507" />

## Notes / Concerns
- Bind mount volumes flags i.e. ` -v ./src:/app/src` and ` -v /app/node_module` are redundant. Should there be any changes in the source code, I will have to rebuild the image.
- It's unlike nodemon, watching and listening for changes in the Node application.
 
